### PR TITLE
Remove npm publish badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 [![CodeQL](https://github.com/F88/protopedia-api-v2-client.js/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/F88/protopedia-api-v2-client.js/actions/workflows/github-code-scanning/codeql)
 [![CI](https://github.com/F88/protopedia-api-v2-client.js/actions/workflows/ci.yml/badge.svg)](https://github.com/F88/protopedia-api-v2-client.js/actions/workflows/ci.yml)
-[![Publish package to npmjs.com](https://github.com/F88/protopedia-api-v2-client.js/actions/workflows/publish-to-npmjs.yml/badge.svg)](https://github.com/F88/protopedia-api-v2-client.js/actions/workflows/publish-to-npmjs.yml)
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/F88/protopedia-api-v2-client.js)
 


### PR DESCRIPTION
Removed the npm publish badge from the README.