### PR TITLE
chore(dev-deps): bump vitest to 4.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@eslint/js": "^9.38.0",
         "@types/node": "^22.7.5",
-        "@vitest/coverage-v8": "^4.0.2",
+        "@vitest/coverage-v8": "^4.0.3",
         "dotenv": "^17.2.3",
         "eslint": "^9.38.0",
         "msw": "^2.11.6",
@@ -19,7 +19,7 @@
         "rimraf": "^6.0.1",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.46.2",
-        "vitest": "^4.0.2"
+        "vitest": "^4.0.3"
       },
       "engines": {
         "node": ">=20"
@@ -1615,14 +1615,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.2.tgz",
-      "integrity": "sha512-daQs7CNoq4KKJ+3mgnxwbX8NLkT3nNxK/ZARdWyy/VtNwe0LoKIHgXFvj0hCKXclgfHaihpqbv1UHkQOgyEZng==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.3.tgz",
+      "integrity": "sha512-I+MlLwyJRBjmJr1kFYSxoseINbIdpxIAeK10jmXgB0FUtIfdYsvM3lGAvBu5yk8WPyhefzdmbCHCc1idFbNRcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.0.2",
+        "@vitest/utils": "4.0.3",
         "ast-v8-to-istanbul": "^0.3.5",
         "debug": "^4.4.3",
         "istanbul-lib-coverage": "^3.2.2",
@@ -1637,8 +1637,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.0.2",
-        "vitest": "4.0.2"
+        "@vitest/browser": "4.0.3",
+        "vitest": "4.0.3"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1647,16 +1647,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.2.tgz",
-      "integrity": "sha512-izQY+ABWqL2Vyr5+LNo3m16nLLTAzLn8em6i5uxqsrWRhdgzdN5JIHrpFVGBAYRGDAbtwE+yD4Heu8gsBSWTVQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.3.tgz",
+      "integrity": "sha512-v3eSDx/bF25pzar6aEJrrdTXJduEBU3uSGXHslIdGIpJVP8tQQHV6x1ZfzbFQ/bLIomLSbR/2ZCfnaEGkWkiVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.2",
-        "@vitest/utils": "4.0.2",
+        "@vitest/spy": "4.0.3",
+        "@vitest/utils": "4.0.3",
         "chai": "^6.0.1",
         "tinyrainbow": "^3.0.3"
       },
@@ -1665,13 +1665,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.2.tgz",
-      "integrity": "sha512-oiny+oBSGU9vHMA1DPdO+t1GVidCRuA4lKSG6rbo5SrCiTCGl7bTCyTaUkwxDpUkiSxEVneeXW4LJ4fg3H56dw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.3.tgz",
+      "integrity": "sha512-evZcRspIPbbiJEe748zI2BRu94ThCBE+RkjCpVF8yoVYuTV7hMe+4wLF/7K86r8GwJHSmAPnPbZhpXWWrg1qbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.2",
+        "@vitest/spy": "4.0.3",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.19"
       },
@@ -1692,9 +1692,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.2.tgz",
-      "integrity": "sha512-PhrSiljryCz5nUDhHla5ihXYy2iRCBob+rNqlu34dA+KZIllVR39rUGny5R3kLgDgw3r8GW1ptOo64WbieMkeQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.3.tgz",
+      "integrity": "sha512-N7gly/DRXzxa9w9sbDXwD9QNFYP2hw90LLLGDobPNwiWgyW95GMxsCt29/COIKKh3P7XJICR38PSDePenMBtsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1705,13 +1705,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.2.tgz",
-      "integrity": "sha512-mPS5T/ZDuO6J5rsQiA76CFmlHtos7dnCvL14I1Oo8SbcjIhJd6kirFmekovfYLRygdF0gJe6SA5asCKIWKw1tw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.3.tgz",
+      "integrity": "sha512-1/aK6fPM0lYXWyGKwop2Gbvz1plyTps/HDbIIJXYtJtspHjpXIeB3If07eWpVH4HW7Rmd3Rl+IS/+zEAXrRtXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.2",
+        "@vitest/utils": "4.0.3",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1719,13 +1719,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.2.tgz",
-      "integrity": "sha512-NibujZAh+fTQlpGdP8J2pZcsPg7EPjiLUOUq9In++4p35vc9xIFMkXfQDbBSpijqZPe6i2hEKrUCbKu70/sPzw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.3.tgz",
+      "integrity": "sha512-amnYmvZ5MTjNCP1HZmdeczAPLRD6iOm9+2nMRUGxbe/6sQ0Ymur0NnR9LIrWS8JA3wKE71X25D6ya/3LN9YytA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.2",
+        "@vitest/pretty-format": "4.0.3",
         "magic-string": "^0.30.19",
         "pathe": "^2.0.3"
       },
@@ -1734,9 +1734,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.2.tgz",
-      "integrity": "sha512-KrTWRXFPYrbhD0iUXeoA8BMXl81nvemj5D8sc7NbTlRvCeUWo36JheOWtAUCafcNi0G72ycAdsvWQVSOxy/3TA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.3.tgz",
+      "integrity": "sha512-82vVL8Cqz7rbXaNUl35V2G7xeNMAjBdNOVaHbrzznT9BmiCiPOzhf0FhU3eP41nP1bLDm/5wWKZqkG4nyU95DQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1744,13 +1744,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.2.tgz",
-      "integrity": "sha512-H9jFzZb/5B5Qh7ajPUWMJ8UYGxQ4EQTaNLSm3icXs/oXkzQ1jqfcWDEJ4U3LkFPZOd6QW8M2MYjz32poW+KKqg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.3.tgz",
+      "integrity": "sha512-qV6KJkq8W3piW6MDIbGOmn1xhvcW4DuA07alqaQ+vdx7YA49J85pnwnxigZVQFQw3tWnQNRKWwhz5wbP6iv/GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.2",
+        "@vitest/pretty-format": "4.0.3",
         "tinyrainbow": "^3.0.3"
       },
       "funding": {
@@ -3984,19 +3984,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.2.tgz",
-      "integrity": "sha512-SXrA2ZzOPulX479d8W13RqKSmvHb9Bfg71eW7Fbs6ZjUFcCCXyt/OzFCkNyiUE8mFlPHa4ZVUGw0ky+5ndKnrg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.3.tgz",
+      "integrity": "sha512-IUSop8jgaT7w0g1yOM/35qVtKjr/8Va4PrjzH1OUb0YH4c3OXB2lCZDkMAB6glA8T5w8S164oJGsbcmAecr4sA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.2",
-        "@vitest/mocker": "4.0.2",
-        "@vitest/pretty-format": "4.0.2",
-        "@vitest/runner": "4.0.2",
-        "@vitest/snapshot": "4.0.2",
-        "@vitest/spy": "4.0.2",
-        "@vitest/utils": "4.0.2",
+        "@vitest/expect": "4.0.3",
+        "@vitest/mocker": "4.0.3",
+        "@vitest/pretty-format": "4.0.3",
+        "@vitest/runner": "4.0.3",
+        "@vitest/snapshot": "4.0.3",
+        "@vitest/spy": "4.0.3",
+        "@vitest/utils": "4.0.3",
         "debug": "^4.4.3",
         "es-module-lexer": "^1.7.0",
         "expect-type": "^1.2.2",
@@ -4024,10 +4024,10 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.2",
-        "@vitest/browser-preview": "4.0.2",
-        "@vitest/browser-webdriverio": "4.0.2",
-        "@vitest/ui": "4.0.2",
+        "@vitest/browser-playwright": "4.0.3",
+        "@vitest/browser-preview": "4.0.3",
+        "@vitest/browser-webdriverio": "4.0.3",
+        "@vitest/ui": "4.0.3",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@eslint/js": "^9.38.0",
     "@types/node": "^22.7.5",
-    "@vitest/coverage-v8": "^4.0.2",
+    "@vitest/coverage-v8": "^4.0.3",
     "dotenv": "^17.2.3",
     "eslint": "^9.38.0",
     "msw": "^2.11.6",
@@ -52,7 +52,7 @@
     "rimraf": "^6.0.1",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.46.2",
-    "vitest": "^4.0.2"
+    "vitest": "^4.0.3"
   },
   "main": "lib/src/index.js",
   "types": "./lib/types/index.d.ts",


### PR DESCRIPTION
This PR bumps Vitest-related dev dependencies to 4.0.3.\n\nChanges:\n- vitest: ^4.0.2 -> ^4.0.3\n- @vitest/coverage-v8: ^4.0.2 -> ^4.0.3\n\nRationale:\n- Patch updates with fixes and internal improvements.\n\nVerification:\n- No source changes.\n- CI should run unit/integration tests per existing scripts.\n\nRisk:\n- Low; dev-only deps.\n\nChore-type PR created automatically.